### PR TITLE
Upgrade datastax java driver to 3.1.0 (fixes #14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.smartcat</groupId>
     <artifactId>cassandra-migration-tool</artifactId>
-    <version>2.1.9.1</version>
+    <version>3.1.0</version>
     <packaging>jar</packaging>
 
     <name>cassandra-migration-tool</name>
@@ -54,13 +54,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <source.level>1.7</source.level>
-        <code.level>1.7</code.level>
-        <version.cassandra-driver>2.1.9</version.cassandra-driver>
-        <version.cassandra-unit>2.1.9.2</version.cassandra-unit>
-        <version.guava>16.0.1</version.guava>
+        <source.level>1.8</source.level>
+        <code.level>1.8</code.level>
+        <version.cassandra-driver>3.1.0</version.cassandra-driver>
+        <version.cassandra-unit>3.0.0.1</version.cassandra-unit>
+        <version.guava>18.0</version.guava>
         <version.slf4j>1.7.7</version.slf4j>
-        <version.junit>4.9</version.junit>
+        <version.junit>4.12</version.junit>
         <version.mockito>1.10.19</version.mockito>
         <version.plugin.jar>2.6</version.plugin.jar>
         <version.plugin.resources>2.7</version.plugin.resources>
@@ -113,6 +113,11 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.fusesource</groupId>
+            <artifactId>sigar</artifactId>
+            <version>1.6.4</version>
         </dependency>
     </dependencies>
 

--- a/src/test/resources/another-cassandra.yaml
+++ b/src/test/resources/another-cassandra.yaml
@@ -27,6 +27,7 @@ hinted_handoff_enabled: true
 # generated.  After it has been dead this long, hints will be dropped.
 max_hint_window_in_ms: 3600000 # one hour
 
+hints_directory: target/embeddedCassandra/hints
 # DEPRECATED : Sleep this long after delivering each hint
 #hinted_handoff_throttle_delay_in_ms: 1
 


### PR DESCRIPTION
Changed to use the datastax java driver version 3.1.0 and related must fixes to get tests to run, bumped the version to match datastax driver as stated in the readme documentation.