### PR TITLE
Change schema_version behavior to allow string versions, run missed versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${version.mockito}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
-
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/src/main/java/io/smartcat/migration/AbstractVersioner.java
+++ b/src/main/java/io/smartcat/migration/AbstractVersioner.java
@@ -2,6 +2,8 @@ package io.smartcat.migration;
 
 import com.datastax.driver.core.Session;
 
+import java.util.Set;
+
 /**
  * Class describing the responsibilities for versioning schema upgrades: mark them
  * as applied in a table, create the table if it doesn't exist, determine which
@@ -27,5 +29,20 @@ public abstract class AbstractVersioner<T> {
      * @param migration Migration that updated the database version
      */
     public abstract void markMigrationAsApplied(Session session, Migration migration);
+
+    /**
+     * @param session active cassandra session
+     * @param migrationType type of migration
+     * @return a set of migration versions which have not yet been applied
+     */
+    public abstract Set<T> getUpdatesApplied(Session session, MigrationType migrationType);
+
+    /**
+     * @param session active cassandra session
+     * @param migrationType type of migration
+     * @return the version of the most recently applied update
+     */
+    public abstract T getMostRecentUpdateApplied(Session session, MigrationType migrationType);
+
 
 }

--- a/src/main/java/io/smartcat/migration/AbstractVersioner.java
+++ b/src/main/java/io/smartcat/migration/AbstractVersioner.java
@@ -1,8 +1,17 @@
 package io.smartcat.migration;
 
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class describing the responsibilities for versioning schema upgrades: mark them
@@ -16,11 +25,68 @@ import java.util.Set;
  */
 public abstract class AbstractVersioner<T> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractVersioner.class);
+
+    /**
+     * Name of the schema_version table.
+     */
+    protected static final String SCHEMA_VERSION_CF = "schema_version";
+
+    /**
+     * Name of the schema_version table.
+     */
+    protected static final String TYPE = "type";
+
+    /**
+     * Name of the version column of the schema_version table.
+     */
+    protected static final String VERSION = "version";
+
+    /**
+     * Name of the version column of the schema_version table.
+     */
+    protected static final String TIMESTAMP = "ts";
+
+    /**
+     * Name of the description table.
+     */
+    protected static final String DESCRIPTION = "description";
+
+    /**
+     * @return the CQL version type in the schema_version table, used to create the table
+     */
+    public abstract String getVersionType();
+
+    /**
+     * @param row - cassandra row containing a version column
+     * @return the java type, or the default type if no row found
+     */
+    protected abstract T getVersion(Optional<Row> row);
+
+    /**
+     *
+     * @return CQL necessary to create the schema_version table
+     */
+    protected String getCreateSchemaVersionTableStatement() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s (",
+                SCHEMA_VERSION_CF)
+                + String.format("%s text,", TYPE)
+                + String.format("%s %s,", VERSION, getVersionType())
+                + String.format("%s bigint,", TIMESTAMP)
+                + String.format("%s text,", DESCRIPTION)
+                + String.format("PRIMARY KEY (%s, %s)", TYPE, VERSION)
+                + String.format(")  WITH CLUSTERING ORDER BY (%s DESC)", VERSION) + " AND COMMENT='Schema version';";
+    }
+
+
     /**
      * Create the table responsible for storing information about migrations already applied.
      * @param session active cassandra session
      */
-    public abstract void bootstrapSchemaVersionTable(Session session);
+    public void bootstrapSchemaVersionTable(Session session) {
+        LOGGER.debug("Try to create schema version column family");
+        session.execute(getCreateSchemaVersionTableStatement());
+    }
 
     /**
      * Update current database version to the migration version. This is executed after migration success.
@@ -28,21 +94,39 @@ public abstract class AbstractVersioner<T> {
      * @param session active cassandra session
      * @param migration Migration that updated the database version
      */
-    public abstract void markMigrationAsApplied(Session session, Migration migration);
+    public void markMigrationAsApplied(final Session session, final Migration migration) {
+        final Statement insert = QueryBuilder.insertInto(SCHEMA_VERSION_CF).value(TYPE, migration.getType().name())
+                .value(VERSION, migration.getVersion()).value(TIMESTAMP, System.currentTimeMillis())
+                .value(DESCRIPTION, migration.getDescription()).setConsistencyLevel(ConsistencyLevel.ALL);
+
+        session.execute(insert);
+    }
 
     /**
      * @param session active cassandra session
      * @param migrationType type of migration
      * @return a set of migration versions which have not yet been applied
      */
-    public abstract Set<T> getUpdatesApplied(Session session, MigrationType migrationType);
+    public Set<T> getUpdatesApplied(Session session, MigrationType migrationType) {
+        final Statement statement = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
+                .where(QueryBuilder.eq(TYPE, migrationType.name()))
+                .setConsistencyLevel(ConsistencyLevel.ALL);
+        final ResultSet resultSet = session.execute(statement);
+        return resultSet.all().stream().map(row -> getVersion(Optional.of(row))).collect(Collectors.toSet());
+    }
 
     /**
      * @param session active cassandra session
      * @param migrationType type of migration
      * @return the version of the most recently applied update
      */
-    public abstract T getMostRecentUpdateApplied(Session session, MigrationType migrationType);
+    public T getMostRecentUpdateApplied(Session session, MigrationType migrationType) {
+        final Statement select = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
+                .where(QueryBuilder.eq(TYPE, migrationType.name())).limit(1).setConsistencyLevel(ConsistencyLevel.ALL);
+        final ResultSet result = session.execute(select);
 
+        final Row row = result.one();
+        return getVersion(Optional.ofNullable(row));
+    }
 
 }

--- a/src/main/java/io/smartcat/migration/AbstractVersioner.java
+++ b/src/main/java/io/smartcat/migration/AbstractVersioner.java
@@ -1,0 +1,31 @@
+package io.smartcat.migration;
+
+import com.datastax.driver.core.Session;
+
+/**
+ * Class describing the responsibilities for versioning schema upgrades: mark them
+ * as applied in a table, create the table if it doesn't exist, determine which
+ * updates have already been applied, and determine which updates must be applied.
+ *
+ * T - the key of the database schema upgrade, i.e an integer
+ *
+ * @param <T> the type of the column to use as version in the database schema upgrade
+ * @author dalvizu
+ */
+public abstract class AbstractVersioner<T> {
+
+    /**
+     * Create the table responsible for storing information about migrations already applied.
+     * @param session active cassandra session
+     */
+    public abstract void bootstrapSchemaVersionTable(Session session);
+
+    /**
+     * Update current database version to the migration version. This is executed after migration success.
+     *
+     * @param session active cassandra session
+     * @param migration Migration that updated the database version
+     */
+    public abstract void markMigrationAsApplied(Session session, Migration migration);
+
+}

--- a/src/main/java/io/smartcat/migration/DataMigration.java
+++ b/src/main/java/io/smartcat/migration/DataMigration.java
@@ -3,7 +3,7 @@ package io.smartcat.migration;
 /**
  * Data migration for migrations manipulating data.
  */
-public abstract class DataMigration extends Migration {
+public abstract class DataMigration extends Migration<Integer> {
 
     /**
      * Creates new data migration.

--- a/src/main/java/io/smartcat/migration/DateStringVersioner.java
+++ b/src/main/java/io/smartcat/migration/DateStringVersioner.java
@@ -1,26 +1,29 @@
 package io.smartcat.migration;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-
 /**
- * Saves migrations with an Integer value.
+ * Version Migrations with a String value assumed to be a timestamp a la
+ * ruby-on-rails active record migrations, e.g: '20180514010203'.
+ *
+ * @author dalvizu
  */
-public class CassandraVersioner
-    extends AbstractVersioner<Integer> {
+public class DateStringVersioner
+    extends AbstractVersioner<String> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraVersioner.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateStringVersioner.class);
 
     private static final String SCHEMA_VERSION_CF = "schema_version";
     private static final String TYPE = "type";
@@ -31,18 +34,26 @@ public class CassandraVersioner
     private static final String CREATE_SCHEMA_VERSION_CQL = String.format("CREATE TABLE IF NOT EXISTS %s (",
             SCHEMA_VERSION_CF)
             + String.format("%s text,", TYPE)
-            + String.format("%s int,", VERSION)
+            + String.format("%s text,", VERSION)
             + String.format("%s bigint,", TIMESTAMP)
             + String.format("%s text,", DESCRIPTION)
             + String.format("PRIMARY KEY (%s, %s)", TYPE, VERSION)
             + String.format(")  WITH CLUSTERING ORDER BY (%s DESC)", VERSION) + " AND COMMENT='Schema version';";
 
     /**
-     * Create Cassandra versioner.
+     * Constructor.
      */
-    public CassandraVersioner() {
+    public  DateStringVersioner() {
+
     }
 
+    /**
+     * @param localDateTime - the date to format
+     * @return a String of the given local date time suitable for saving to the database as a version
+     */
+    public static String getDateString(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+    }
 
     @Override
     public void bootstrapSchemaVersionTable(Session session) {
@@ -50,22 +61,8 @@ public class CassandraVersioner
         session.execute(CREATE_SCHEMA_VERSION_CQL);
     }
 
-    /**
-     * Get current database version for given migration type with ALL consistency. Select one row since
-     * migration history is saved ordered descending by timestamp. If there are no rows in the schema_version table,
-     * return 0 as default database version. Data version is changed by executing migrations.
-     *
-     * @deprecated use #getMostRecentUpdateApplied()
-     * @param session Active cassandra session
-     * @param type Migration type
-     * @return Database version for given type
-     */
-    public int getCurrentVersion(final Session session, final MigrationType type) {
-        return getMostRecentUpdateApplied(session, type);
-    }
-
     @Override
-    public void markMigrationAsApplied(final Session session, final Migration migration) {
+    public void markMigrationAsApplied(Session session, Migration migration) {
         final Statement insert = QueryBuilder.insertInto(SCHEMA_VERSION_CF).value(TYPE, migration.getType().name())
                 .value(VERSION, migration.getVersion()).value(TIMESTAMP, System.currentTimeMillis())
                 .value(DESCRIPTION, migration.getDescription()).setConsistencyLevel(ConsistencyLevel.ALL);
@@ -74,22 +71,21 @@ public class CassandraVersioner
     }
 
     @Override
-    public Set<Integer> getUpdatesApplied(Session session, MigrationType migrationType) {
+    public Set<String> getUpdatesApplied(Session session, MigrationType migrationType) {
         final Statement statement = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
                 .where(QueryBuilder.eq(TYPE, migrationType.name()))
                 .setConsistencyLevel(ConsistencyLevel.ALL);
         final ResultSet resultSet = session.execute(statement);
-        return resultSet.all().stream().map(row -> row.getInt(VERSION)).collect(Collectors.toSet());
+        return resultSet.all().stream().map(row -> row.getString(VERSION)).collect(Collectors.toSet());
     }
 
     @Override
-    public Integer getMostRecentUpdateApplied(Session session, MigrationType migrationType) {
+    public String getMostRecentUpdateApplied(Session session, MigrationType migrationType) {
         final Statement select = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
                 .where(QueryBuilder.eq(TYPE, migrationType.name())).limit(1).setConsistencyLevel(ConsistencyLevel.ALL);
         final ResultSet result = session.execute(select);
 
         final Row row = result.one();
-        return row == null ? 0 : row.getInt(VERSION);
+        return row == null ? "" : row.getString(VERSION);
     }
-
 }

--- a/src/main/java/io/smartcat/migration/DateStringVersioner.java
+++ b/src/main/java/io/smartcat/migration/DateStringVersioner.java
@@ -1,18 +1,10 @@
 package io.smartcat.migration;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.Statement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 /**
  * Version Migrations with a String value assumed to be a timestamp a la
@@ -23,22 +15,11 @@ import java.util.stream.Collectors;
 public class DateStringVersioner
     extends AbstractVersioner<String> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DateStringVersioner.class);
 
-    private static final String SCHEMA_VERSION_CF = "schema_version";
-    private static final String TYPE = "type";
-    private static final String VERSION = "version";
-    private static final String TIMESTAMP = "ts";
-    private static final String DESCRIPTION = "description";
-
-    private static final String CREATE_SCHEMA_VERSION_CQL = String.format("CREATE TABLE IF NOT EXISTS %s (",
-            SCHEMA_VERSION_CF)
-            + String.format("%s text,", TYPE)
-            + String.format("%s text,", VERSION)
-            + String.format("%s bigint,", TIMESTAMP)
-            + String.format("%s text,", DESCRIPTION)
-            + String.format("PRIMARY KEY (%s, %s)", TYPE, VERSION)
-            + String.format(")  WITH CLUSTERING ORDER BY (%s DESC)", VERSION) + " AND COMMENT='Schema version';";
+    @Override
+    public String getVersionType() {
+        return "text";
+    }
 
     /**
      * Constructor.
@@ -56,36 +37,7 @@ public class DateStringVersioner
     }
 
     @Override
-    public void bootstrapSchemaVersionTable(Session session) {
-        LOGGER.debug("Try to create schema version column family");
-        session.execute(CREATE_SCHEMA_VERSION_CQL);
-    }
-
-    @Override
-    public void markMigrationAsApplied(Session session, Migration migration) {
-        final Statement insert = QueryBuilder.insertInto(SCHEMA_VERSION_CF).value(TYPE, migration.getType().name())
-                .value(VERSION, migration.getVersion()).value(TIMESTAMP, System.currentTimeMillis())
-                .value(DESCRIPTION, migration.getDescription()).setConsistencyLevel(ConsistencyLevel.ALL);
-
-        session.execute(insert);
-    }
-
-    @Override
-    public Set<String> getUpdatesApplied(Session session, MigrationType migrationType) {
-        final Statement statement = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
-                .where(QueryBuilder.eq(TYPE, migrationType.name()))
-                .setConsistencyLevel(ConsistencyLevel.ALL);
-        final ResultSet resultSet = session.execute(statement);
-        return resultSet.all().stream().map(row -> row.getString(VERSION)).collect(Collectors.toSet());
-    }
-
-    @Override
-    public String getMostRecentUpdateApplied(Session session, MigrationType migrationType) {
-        final Statement select = QueryBuilder.select().all().from(SCHEMA_VERSION_CF)
-                .where(QueryBuilder.eq(TYPE, migrationType.name())).limit(1).setConsistencyLevel(ConsistencyLevel.ALL);
-        final ResultSet result = session.execute(select);
-
-        final Row row = result.one();
-        return row == null ? "" : row.getString(VERSION);
+    protected String getVersion(Optional<Row> row) {
+        return row.isPresent() ? row.get().getString(VERSION) : "";
     }
 }

--- a/src/main/java/io/smartcat/migration/Migration.java
+++ b/src/main/java/io/smartcat/migration/Migration.java
@@ -9,10 +9,11 @@ import io.smartcat.migration.exceptions.SchemaAgreementException;
 
 /**
  * Abstract migration class that implements session DI and exposes required methods for execution.
+ * @param <T> type of the version in the database schema describing migration applied
  */
-public abstract class Migration {
+public abstract class Migration<T extends Comparable> {
 
-    private int version = -1;
+    private T version;
     private MigrationType type = MigrationType.SCHEMA;
 
     /**
@@ -25,7 +26,7 @@ public abstract class Migration {
      * @param type Migration type (SCHEMA or DATA)
      * @param version Migration version
      */
-    public Migration(final MigrationType type, final int version) {
+    public Migration(final MigrationType type, final T version) {
         this.type = type;
         this.version = version;
     }
@@ -50,7 +51,7 @@ public abstract class Migration {
      * Returns resulting database schema version of this migration.
      * @return Resulting db schema version
      */
-    public int getVersion() {
+    public T getVersion() {
         return this.version;
     }
 
@@ -126,7 +127,7 @@ public abstract class Migration {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((type == null) ? 0 : type.hashCode());
-        result = prime * result + version;
+        result = prime * result + version.hashCode();
         return result;
     }
 

--- a/src/main/java/io/smartcat/migration/MigrationEngine.java
+++ b/src/main/java/io/smartcat/migration/MigrationEngine.java
@@ -16,11 +16,107 @@ public class MigrationEngine {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MigrationEngine.class);
 
-    private MigrationEngine() {
+    private final Session session;
+    private final AbstractVersioner versioner;
+
+    /**
+     * Private constructor - use use MigrationEngine.Builder() instead.
+     * @param session active cassandra session
+     * @param versioner the versioner to use to interact with schema_verion table
+     */
+    private MigrationEngine(final Session session, final AbstractVersioner versioner) {
+        this.session = session;
+        this.versioner = versioner;
+        versioner.bootstrapSchemaVersionTable(session);
+    }
+
+    /**
+     * Builder for MigrationEngine, used to construct a MigrationEngine object.
+     */
+    public static class Builder {
+        // See Josh Bloch's 'Effective Java' for this pattern
+
+        private AbstractVersioner versioner = new CassandraVersioner();
+
+        /**
+         * Set the Versioner to use, defaults to CassandraVersioner.
+         * @param versioner versioner to use
+         * @return this
+         */
+        public Builder withVersioner(AbstractVersioner versioner) {
+            this.versioner = versioner;
+            return this;
+        }
+
+        /**
+         * Construct a MigrationEngine object.
+         * @param session active Cassandra migration
+         * @return a MigrationEngine object
+         */
+        public MigrationEngine build(Session session) {
+
+            return new MigrationEngine(session, versioner);
+        }
+    }
+
+    /**
+     * Method that executes all migration from migration resources that are higher version than db version. If
+     * migration fails, method will exit.
+     *
+     * @param resources Collection of migrations to be executed
+     * @return Success of migration
+     */
+    public boolean migrate(final MigrationResources resources) {
+        LOGGER.debug("Start migration");
+
+        for (final Migration migration : resources.getMigrations()) {
+            final MigrationType type = migration.getType();
+            final Comparable migrationVersion = migration.getVersion();
+            final Object version = versioner.getMostRecentUpdateApplied(session, migration.getType());
+
+            LOGGER.info("Db is version {} for type {}.", version, type.name());
+            LOGGER.info("Compare {} migration version {} with description {}", type.name(), migrationVersion,
+                    migration.getDescription());
+
+            if (versioner.getUpdatesApplied(session, migration.getType()).contains(migration.getVersion())) {
+                LOGGER.warn("Skipping migration [{}] with version {} since db already has it applied {}.",
+                        migration.getDescription(), migrationVersion, version);
+                continue;
+            }
+
+            migration.setSession(session);
+
+            final long start = System.currentTimeMillis();
+            LOGGER.info("Start executing migration to version {}.", migrationVersion);
+
+            try {
+                migration.execute();
+            } catch (final MigrationException e) {
+                LOGGER.error("Failed to execute migration version {}, exception {}!", migrationVersion,
+                        e);
+                LOGGER.debug("Exception stack trace: {}", e);
+                return false;
+            }
+
+            final long end = System.currentTimeMillis();
+            final long seconds = (end - start) / 1000;
+            LOGGER.info("Migration [{}] to version {} finished in {} seconds.", migration.getDescription(),
+                    migrationVersion, seconds);
+
+            try {
+                versioner.markMigrationAsApplied(session, migration);
+            } catch (final Exception e) {
+                LOGGER.error("Db schema update failed for migration version {}!", migrationVersion);
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
      * Create migrator out of session fully prepared for doing migration of resources.
+     * @deprecated preseved for compatability - do not use
      * @param session Datastax driver session object
      * @return migrator instance with versioner and session which can migrate resources
      */
@@ -30,75 +126,17 @@ public class MigrationEngine {
 
     /**
      * Migrator handles migrations and errors.
-     * @deprecated do not use - kept for compatability reasons
+     * @deprecated do not use - kept for compatability reasons. Use MigrationEngine directly
      */
-    public static class Migrator {
-        private final Session session;
-        private final CassandraVersioner versioner;
+    public static class Migrator
+        extends MigrationEngine {
 
         /**
-         * Create new Migrator with active Cassandra session.
-         * @param session Active Cassandra session
+         * @deprecated do not use - use MigrationEngine.Builder() instead
+         * @param session active cassandra session
          */
-        public Migrator(final Session session) {
-            this.session = session;
-            this.versioner = new CassandraVersioner();
-            versioner.bootstrapSchemaVersionTable(session);
-        }
-
-        /**
-         * Method that executes all migration from migration resources that are higher version than db version. If
-         * migration fails, method will exit.
-         *
-         * @param resources Collection of migrations to be executed
-         * @return Success of migration
-         */
-        public boolean migrate(final MigrationResources resources) {
-            LOGGER.debug("Start migration");
-
-            for (final Migration migration : resources.getMigrations()) {
-                final MigrationType type = migration.getType();
-                final Comparable migrationVersion = migration.getVersion();
-                final int version = versioner.getCurrentVersion(session, migration.getType());
-
-                LOGGER.info("Db is version {} for type {}.", version, type.name());
-                LOGGER.info("Compare {} migration version {} with description {}", type.name(), migrationVersion,
-                        migration.getDescription());
-
-                if (versioner.getUpdatesApplied(session, migration.getType()).contains(migration.getVersion())) {
-                    LOGGER.warn("Skipping migration [{}] with version {} since db already has it applied {}.",
-                            migration.getDescription(), migrationVersion, version);
-                    continue;
-                }
-
-                migration.setSession(session);
-
-                final long start = System.currentTimeMillis();
-                LOGGER.info("Start executing migration to version {}.", migrationVersion);
-
-                try {
-                    migration.execute();
-                } catch (final MigrationException e) {
-                    LOGGER.error("Failed to execute migration version {}, exception {}!", migrationVersion,
-                            e.getMessage());
-                    LOGGER.debug("Exception stack trace: {}", e);
-                    return false;
-                }
-
-                final long end = System.currentTimeMillis();
-                final long seconds = (end - start) / 1000;
-                LOGGER.info("Migration [{}] to version {} finished in {} seconds.", migration.getDescription(),
-                        migrationVersion, seconds);
-
-                try {
-                    versioner.markMigrationAsApplied(session, migration);
-                } catch (final Exception e) {
-                    LOGGER.error("Db schema update failed for migration version {}!", migrationVersion);
-                    return false;
-                }
-            }
-
-            return true;
+        public Migrator(Session session) {
+            super(session, new CassandraVersioner());
         }
     }
 

--- a/src/main/java/io/smartcat/migration/MigrationEngine.java
+++ b/src/main/java/io/smartcat/migration/MigrationEngine.java
@@ -30,6 +30,7 @@ public class MigrationEngine {
 
     /**
      * Migrator handles migrations and errors.
+     * @deprecated do not use - kept for compatability reasons
      */
     public static class Migrator {
         private final Session session;
@@ -64,8 +65,8 @@ public class MigrationEngine {
                 LOGGER.info("Compare {} migration version {} with description {}", type.name(), migrationVersion,
                         migration.getDescription());
 
-                if (migrationVersion.compareTo(version) <= 0) {
-                    LOGGER.warn("Skipping migration [{}] with version {} since db is on higher version {}.",
+                if (versioner.getUpdatesApplied(session, migration.getType()).contains(migration.getVersion())) {
+                    LOGGER.warn("Skipping migration [{}] with version {} since db already has it applied {}.",
                             migration.getDescription(), migrationVersion, version);
                     continue;
                 }

--- a/src/main/java/io/smartcat/migration/SchemaMigration.java
+++ b/src/main/java/io/smartcat/migration/SchemaMigration.java
@@ -3,7 +3,7 @@ package io.smartcat.migration;
 /**
  * Schema migration for migrations manipulating schema.
  */
-public abstract class SchemaMigration extends Migration {
+public abstract class SchemaMigration extends Migration<Integer> {
 
     /**
      * Create new schema migration with provided version.

--- a/src/test/java/io/smartcat/migration/CassandraVersionerTest.java
+++ b/src/test/java/io/smartcat/migration/CassandraVersionerTest.java
@@ -26,7 +26,7 @@ public class CassandraVersionerTest {
     @Before
     public void setUp() throws Exception {
         session = mock(Session.class);
-        versioner = new CassandraVersioner(session);
+        versioner = new CassandraVersioner();
         versionResultSet = mock(ResultSet.class);
     }
 
@@ -34,7 +34,7 @@ public class CassandraVersionerTest {
     public void whenSchemaVersionTableIsEmptyThenCurrentVersionShouldBe0() throws Exception {
         expectRetrieveEmptyCurrentVersion();
 
-        int currentVersion = versioner.getCurrentVersion(SCHEMA);
+        int currentVersion = versioner.getCurrentVersion(session, SCHEMA);
 
         assertThat(currentVersion, is(0));
     }
@@ -45,14 +45,14 @@ public class CassandraVersionerTest {
 
         expectRetrieveCurrentVersion(expectedVersion);
 
-        int currentVersion = versioner.getCurrentVersion(SCHEMA);
+        int currentVersion = versioner.getCurrentVersion(session, SCHEMA);
 
         assertThat(currentVersion, is(expectedVersion));
     }
 
     @Test
     public void updateVersionSucess() throws Exception {
-        versioner.updateVersion(new AddBookGenreFieldMigration(1));
+        versioner.markMigrationAsApplied(session, new AddBookGenreFieldMigration(1));
     }
 
     private void expectRetrieveEmptyCurrentVersion() {

--- a/src/test/java/io/smartcat/migration/CassandraVersionerTest.java
+++ b/src/test/java/io/smartcat/migration/CassandraVersionerTest.java
@@ -52,7 +52,7 @@ public class CassandraVersionerTest {
 
     @Test
     public void updateVersionSucess() throws Exception {
-        versioner.markMigrationAsApplied(session, new AddBookGenreFieldMigration(1));
+        versioner.markMigrationAsApplied(session, new AddBookGenreFieldMigration<>(1));
     }
 
     private void expectRetrieveEmptyCurrentVersion() {

--- a/src/test/java/io/smartcat/migration/DateStringVersionerTest.java
+++ b/src/test/java/io/smartcat/migration/DateStringVersionerTest.java
@@ -1,0 +1,101 @@
+package io.smartcat.migration;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import io.smartcat.migration.migrations.schema.AddBookGenreFieldMigration;
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author dalvizu
+ */
+public class DateStringVersionerTest
+    extends BaseTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateStringVersionerTest.class);
+
+    private static final String CONTACT_POINT = "localhost";
+    private static final int PORT = 9142;
+    private static final String KEYSPACE = "migration_test_items";
+    private static final String CQL = "items.cql";
+
+    private static Session session;
+    private static Cluster cluster;
+
+    private DateStringVersioner versioner;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Starting embedded cassandra server");
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra("another-cassandra.yaml");
+
+        LOGGER.info("Connect to embedded db");
+        cluster = Cluster.builder().addContactPoints(CONTACT_POINT).withPort(PORT).build();
+        session = cluster.connect();
+
+        LOGGER.info("Initialize keyspace");
+        final CQLDataLoader cqlDataLoader = new CQLDataLoader(session);
+        cqlDataLoader.load(new ClassPathCQLDataSet(CQL, false, true, KEYSPACE));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (cluster != null) {
+            cluster.close();
+            cluster = null;
+        }
+    }
+
+    @Before
+    public void setup() {
+        versioner = new DateStringVersioner();
+        versioner.bootstrapSchemaVersionTable(session);
+    }
+
+    @Test
+    public void testDateFormat() {
+        LocalDateTime firstDate /* aww */  = LocalDate.of(2018, 05, 01)
+                .atTime(06, 13, 14);
+
+        String dateString = DateStringVersioner.getDateString(firstDate);
+        assertEquals("20180501061314", dateString);
+
+        LocalDateTime secondDate  = LocalDate.of(2018, 05, 01)
+                .atTime(18, 13, 14);
+
+        dateString = DateStringVersioner.getDateString(secondDate);
+        assertEquals("20180501181314", dateString);
+
+    }
+
+//    @Test
+//    public void testNoUpdatesApplied() {
+//        assertThat(versioner.getUpdatesApplied(session, MigrationType.SCHEMA), is(empty()));
+//    }
+
+    @Test
+    public void testApplyMigration() {
+        AddBookGenreFieldMigration migration = new AddBookGenreFieldMigration("20180506010203");
+        versioner.markMigrationAsApplied(session, migration);
+        assertThat(versioner.getUpdatesApplied(session, migration.getType()), not(empty()));
+        assertThat(versioner.getUpdatesApplied(session, migration.getType()), contains(migration.getVersion()));
+        assertEquals(migration.getVersion(), versioner.getMostRecentUpdateApplied(session, migration.getType()));
+    }
+
+}

--- a/src/test/java/io/smartcat/migration/MigrationEngineDateStringFuncTest.java
+++ b/src/test/java/io/smartcat/migration/MigrationEngineDateStringFuncTest.java
@@ -1,0 +1,96 @@
+package io.smartcat.migration;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import io.smartcat.migration.migrations.data.AddGenreMigration;
+import io.smartcat.migration.migrations.data.InsertBooksMigration;
+import io.smartcat.migration.migrations.schema.AddBookGenreFieldMigration;
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Functional test demonstrating MigrationEngine working with a DateStringVersioner.
+ * @author dalvizu
+ */
+public class MigrationEngineDateStringFuncTest extends BaseTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationEngineDateStringFuncTest.class);
+
+    private static final String CONTACT_POINT = "localhost";
+    private static final int PORT = 9142;
+    private static final String KEYSPACE = "migration_test_books";
+    private static final String CQL = "books.cql";
+
+    private static Session session;
+    private static Cluster cluster;
+
+    private MigrationEngine engine;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Starting embedded cassandra server");
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra("another-cassandra.yaml");
+
+        LOGGER.info("Connect to embedded db");
+        cluster = Cluster.builder().addContactPoints(CONTACT_POINT).withPort(PORT).build();
+        session = cluster.connect();
+
+        LOGGER.info("Initialize keyspace");
+        final CQLDataLoader cqlDataLoader = new CQLDataLoader(session);
+        cqlDataLoader.load(new ClassPathCQLDataSet(CQL, false, true, KEYSPACE));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (cluster != null) {
+            cluster.close();
+            cluster = null;
+        }
+    }
+    @Before
+    public void setup() {
+        engine = new MigrationEngine.Builder().withVersioner(new DateStringVersioner()).build(session);
+    }
+
+    @Test
+    public void test_migrations() {
+        final MigrationResources initialResources = new MigrationResources();
+        initialResources.addMigration(new InsertBooksMigration("123"));
+        engine.migrate(initialResources);
+
+        final MigrationResources resources = new MigrationResources();
+        resources.addMigration(new AddBookGenreFieldMigration("456"));
+        resources.addMigration(new AddGenreMigration("789"));
+        engine.migrate(resources);
+
+        final Statement select = QueryBuilder.select().all().from("books");
+        final ResultSet results = session.execute(select);
+
+        for (final Row row : results) {
+            final String genre = row.getString("genre");
+            final String name = row.getString("name");
+
+            if (name.equals("Journey to the Center of the Earth")) {
+                assertEquals("fantasy", genre);
+            } else if (name.equals("Fifty Shades of Grey")) {
+                assertEquals("erotica", genre);
+            } else {
+                assertEquals("programming", genre);
+            }
+        }
+    }
+
+}

--- a/src/test/java/io/smartcat/migration/MigrationTestingOrderingTest.java
+++ b/src/test/java/io/smartcat/migration/MigrationTestingOrderingTest.java
@@ -1,0 +1,92 @@
+package io.smartcat.migration;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import io.smartcat.migration.migrations.schema.AddBookGenreFieldMigration;
+import io.smartcat.migration.migrations.schema.AddBookISBNFieldMigration;
+import io.smartcat.migration.migrations.schema.CreateItemByNumberAndExternalIdMigration;
+import org.cassandraunit.CQLDataLoader;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * @author dalvizu
+ */
+public class MigrationTestingOrderingTest extends BaseTest {
+    private static Session session;
+
+    private static Cluster cluster;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationEngineBooksTest.class);
+
+    private static final String CONTACT_POINT = "localhost";
+    private static final int PORT = 9142;
+    private static final String KEYSPACE = "migration_test_books";
+    private static final String CQL = "books.cql";
+
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Starting embedded cassandra server");
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra("another-cassandra.yaml");
+
+        LOGGER.info("Connect to embedded db");
+        cluster = Cluster.builder().addContactPoints(CONTACT_POINT).withPort(PORT).build();
+        session = cluster.connect();
+
+        LOGGER.info("Initialize keyspace");
+        final CQLDataLoader cqlDataLoader = new CQLDataLoader(session);
+        cqlDataLoader.load(new ClassPathCQLDataSet(CQL, false, true, KEYSPACE));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (cluster != null) {
+            cluster.close();
+            cluster = null;
+        }
+    }
+
+    @Test
+    public void noUpdatesToApply() {
+        CassandraVersioner versioner = new CassandraVersioner();
+        final MigrationResources resources = new MigrationResources();
+        resources.addMigration(new AddBookGenreFieldMigration(1));
+
+        boolean result = MigrationEngine.withSession(session).migrate(resources);
+        assertEquals(true, result);
+        assertEquals(Integer.valueOf(1), versioner.getMostRecentUpdateApplied(session, MigrationType.SCHEMA));
+
+        result = MigrationEngine.withSession(session).migrate(resources);
+        assertEquals(true, result);
+        assertEquals(Integer.valueOf(1), versioner.getMostRecentUpdateApplied(session, MigrationType.SCHEMA));
+    }
+
+    @Test
+    public void testUpdatesArriveOutOfOrder() {
+
+        CassandraVersioner cassandraVersioner = new CassandraVersioner();
+        final MigrationResources resources = new MigrationResources();
+        resources.addMigration(new AddBookGenreFieldMigration(1));
+        resources.addMigration(new AddBookISBNFieldMigration(3));
+
+        boolean result = MigrationEngine.withSession(session).migrate(resources);
+        assertEquals(true, result);
+        assertThat(cassandraVersioner.getUpdatesApplied(session, MigrationType.SCHEMA), contains(1, 3));
+        assertEquals(3, cassandraVersioner.getCurrentVersion(session, MigrationType.SCHEMA));
+
+        resources.addMigration(new CreateItemByNumberAndExternalIdMigration(2));
+        result = MigrationEngine.withSession(session).migrate(resources);
+        assertEquals(true, result);
+        assertEquals(3, cassandraVersioner.getCurrentVersion(session, MigrationType.SCHEMA));
+        assertThat(cassandraVersioner.getUpdatesApplied(session, MigrationType.SCHEMA), contains(1, 2, 3));
+    }
+}

--- a/src/test/java/io/smartcat/migration/MigratorTest.java
+++ b/src/test/java/io/smartcat/migration/MigratorTest.java
@@ -109,7 +109,7 @@ public class MigratorTest extends BaseTest {
     }
 
     @Test
-    public void skipMigrationWithVersionOlderThanCurrentSchemaVersion() throws Exception {
+    public void doNotSkipMigrationWithVersionOlderThanCurrentSchemaVersion() throws Exception {
         Migration migrationWithNewerVersion = new AddBookGenreFieldMigration(2);
         Migration migrationWithOlderVersion = new AddBookISBNFieldMigration(1);
 
@@ -121,7 +121,7 @@ public class MigratorTest extends BaseTest {
 
         // verify
         assertThat(getCurrentVersion(), is(migrationWithNewerVersion.getVersion()));
-        assertTableDoesntContainsColumns("books", "isbn");
+        assertTableContainsColumns("books", "isbn");
     }
 
     @Test

--- a/src/test/java/io/smartcat/migration/MigratorTest.java
+++ b/src/test/java/io/smartcat/migration/MigratorTest.java
@@ -55,7 +55,7 @@ public class MigratorTest extends BaseTest {
         final CQLDataLoader cqlDataLoader = new CQLDataLoader(session);
         cqlDataLoader.load(new ClassPathCQLDataSet(CQL, false, true, KEYSPACE));
 
-        versioner = new CassandraVersioner(session);
+        versioner = new CassandraVersioner();
         migrator = MigrationEngine.withSession(session);
         metadataAnalyzer = new CassandraMetadataAnalyzer(session);
     }
@@ -138,7 +138,7 @@ public class MigratorTest extends BaseTest {
     }
 
     private int getCurrentVersion() {
-        return versioner.getCurrentVersion(MigrationType.SCHEMA);
+        return versioner.getCurrentVersion(session, MigrationType.SCHEMA);
     }
 
     private void assertTableDoesntContainsColumns(String table, String... columns) {

--- a/src/test/java/io/smartcat/migration/migrations/data/AddGenreMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/data/AddGenreMigration.java
@@ -7,16 +7,17 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 
-import io.smartcat.migration.DataMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
 /**
  * Example of data migration which will go through all entries in DB and for each add genre. Real life example which
  * covers this case is adding of new column to DB and need to populate it with some data for already existing entries
  */
-public class AddGenreMigration extends DataMigration {
-    public AddGenreMigration(final int version) {
-        super(version);
+public class AddGenreMigration<T extends Comparable> extends Migration {
+    public AddGenreMigration(final T version) {
+        super(MigrationType.DATA, version);
     }
 
     @Override

--- a/src/test/java/io/smartcat/migration/migrations/data/InsertBooksMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/data/InsertBooksMigration.java
@@ -2,17 +2,18 @@ package io.smartcat.migration.migrations.data;
 
 import com.datastax.driver.core.PreparedStatement;
 
-import io.smartcat.migration.DataMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
 /**
  * Example of data migration used for populating data in table. This shows use case when you need to populate data in
  * table fast. Can be used for test data, logic can be added to add near production like data in huge amounts.
  */
-public class InsertBooksMigration extends DataMigration {
+public class InsertBooksMigration<T extends Comparable> extends Migration {
 
-    public InsertBooksMigration(final int version) {
-        super(version);
+    public InsertBooksMigration(final T version) {
+        super(MigrationType.DATA, version);
     }
 
     @Override

--- a/src/test/java/io/smartcat/migration/migrations/data/InsertInitialItemsMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/data/InsertInitialItemsMigration.java
@@ -1,17 +1,18 @@
 package io.smartcat.migration.migrations.data;
 
 import com.datastax.driver.core.PreparedStatement;
-import io.smartcat.migration.DataMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
 import java.util.UUID;
 
-public class InsertInitialItemsMigration extends DataMigration {
+public class InsertInitialItemsMigration<T extends Comparable> extends Migration {
 
     private final int count;
 
-    public InsertInitialItemsMigration(final int count, final int version) {
-        super(version);
+    public InsertInitialItemsMigration(final int count, final T version) {
+        super(MigrationType.DATA, version);
         this.count = count;
     }
 

--- a/src/test/java/io/smartcat/migration/migrations/data/PopulateItemByNumberAndExternalIdMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/data/PopulateItemByNumberAndExternalIdMigration.java
@@ -6,13 +6,14 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 
-import io.smartcat.migration.DataMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
-public class PopulateItemByNumberAndExternalIdMigration extends DataMigration {
+public class PopulateItemByNumberAndExternalIdMigration<T extends Comparable> extends Migration {
 
-    public PopulateItemByNumberAndExternalIdMigration(final int version) {
-        super(version);
+    public PopulateItemByNumberAndExternalIdMigration(final T version) {
+        super(MigrationType.DATA, version);
     }
 
     @Override

--- a/src/test/java/io/smartcat/migration/migrations/schema/AddBookGenreFieldMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/schema/AddBookGenreFieldMigration.java
@@ -2,16 +2,18 @@ package io.smartcat.migration.migrations.schema;
 
 import com.datastax.driver.core.SimpleStatement;
 
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
-import io.smartcat.migration.SchemaMigration;
+
 
 /**
  * Example of schema migration which adds new column to existing table.
  */
-public class AddBookGenreFieldMigration extends SchemaMigration {
+public class AddBookGenreFieldMigration<T extends Comparable> extends Migration {
 
-    public AddBookGenreFieldMigration(final int version) {
-        super(version);
+    public AddBookGenreFieldMigration(final T value) {
+        super(MigrationType.SCHEMA, value);
     }
 
     @Override

--- a/src/test/java/io/smartcat/migration/migrations/schema/AddBookISBNFieldMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/schema/AddBookISBNFieldMigration.java
@@ -2,16 +2,17 @@ package io.smartcat.migration.migrations.schema;
 
 import com.datastax.driver.core.SimpleStatement;
 
-import io.smartcat.migration.SchemaMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
 /**
  * Example of schema migration which adds new column to existing table.
  */
-public class AddBookISBNFieldMigration extends SchemaMigration {
+public class AddBookISBNFieldMigration<T extends Comparable> extends Migration {
 
-    public AddBookISBNFieldMigration(final int version) {
-        super(version);
+    public AddBookISBNFieldMigration(final T version) {
+        super(MigrationType.SCHEMA, version);
     }
 
     @Override

--- a/src/test/java/io/smartcat/migration/migrations/schema/CreateItemByNumberAndExternalIdMigration.java
+++ b/src/test/java/io/smartcat/migration/migrations/schema/CreateItemByNumberAndExternalIdMigration.java
@@ -1,13 +1,14 @@
 package io.smartcat.migration.migrations.schema;
 
 import com.datastax.driver.core.SimpleStatement;
-import io.smartcat.migration.SchemaMigration;
+import io.smartcat.migration.Migration;
+import io.smartcat.migration.MigrationType;
 import io.smartcat.migration.exceptions.MigrationException;
 
-public class CreateItemByNumberAndExternalIdMigration extends SchemaMigration {
+public class CreateItemByNumberAndExternalIdMigration<T extends Comparable> extends Migration {
 
-    public CreateItemByNumberAndExternalIdMigration(final int version) {
-        super(version);
+    public CreateItemByNumberAndExternalIdMigration(final T version) {
+        super(MigrationType.SCHEMA, version);
     }
 
     @Override

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <!-- Reduce amount of logging -->
     <logger name="org.apache.cassandra" level="WARN" />
     <logger name="org.datastax" level="WARN" />
+    <logger name="com.datastax" level="WARN" />
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
 
 </configuration>


### PR DESCRIPTION
Fixes #33 #34

This PR is broken out into commits showing refactors (code changes but no behavior change) vs behavior changes for easier review.

Behavior changes:

* Migrations which could have been 'skipped' if they were not applied and less than the 'current schema version' will now be re-run

New functionality:

* Users of this library will now be able to build their MigrationEngine and specify which Versioner to use (or specify their own custom one).
* Added support for using a rails-like date string format for version (`DateStringVersioner`)

This should not result in API breakage for existing clients, although they will see deprecation warnings.

Misc:
* Added logging to unit tests
* Explicitly declare hamcrest test dependency
